### PR TITLE
Add pause to see error msg if path not found

### DIFF
--- a/Fallout 76 Language Changer.bat
+++ b/Fallout 76 Language Changer.bat
@@ -105,6 +105,7 @@ if "%restore_only%"=="1" goto RESTORE_ONLY
 REM Preflight checks and launch
 if not exist "%Path_to_Fallout76_Gamepass.exe%" (
   echo Error: Could not find the game executable at the specified path.
+  pause
   exit /b 2
 )
 


### PR DESCRIPTION
Issue: when the game .exe is not found the cmd box will close without any useful info.

Fix: add pause so the user has to manually input a keystroke after reading that the path is not correct.
